### PR TITLE
Remove book swap chair application

### DIFF
--- a/elections/templates/elections/list.html
+++ b/elections/templates/elections/list.html
@@ -11,7 +11,7 @@
 <a class="btn btn-default" href="http://tinyurl.com/EVP-2016">Apply to be an External Vice President</a>
 <a class="btn btn-default" href="https://goo.gl/forms/pL0x677rPSh51Mky1">Apply to be a K-12 Outreach Officer</a>
 {#<a class="btn btn-default" href="http://tinyurl.com/ConvChairW16">Apply to be the Convention Arrangements Chair</a>#}
-<a class="btn btn-default" href="http://tinyurl.com/BookSwapW16">Apply to be a Book Swap Chair</a>
+{#<a class="btn btn-default" href="http://tinyurl.com/BookSwapW16">Apply to be a Book Swap Chair</a>#}
 </div>
 {% if nominees %}
 <table class="table table-bordered table-striped">


### PR DESCRIPTION
Remove link to apply to serve as a book swap chair. The chapter has discontinued hosting the book swap.