### PR TITLE
Enable K-12 outreach officers to view members’ background check status

### DIFF
--- a/member_resources/templates/member_resources/userprofile.html
+++ b/member_resources/templates/member_resources/userprofile.html
@@ -39,38 +39,39 @@
 
                 <p class="text-justify"><b>Bio: </b>{{profile.short_bio|my_markdown}}</p>
                 {% if full_view %}
-                {% if is_user %}<h4>Your info (only visible to you and to admins):</h4>{% endif %}
-                <p><b>UMID:</b> {{profile.UMID}}</p>
-                <p><b>Expected Graduation Date:</b> {{profile.expect_grad_date|date:"N j, Y"}}</p>
-                {% if profile.edu_bckgrd_form %}
-                <p><b>Educational Background Form:</b> <a href="{{profile.edu_bckgrd_form.url}}">Link</a>
-                {% endif %}
-                {% if checks %}
-                <p><b>Background Checks on file:</b><br/>
-                This lists the date the check was filed. AAPS background checks and BSA training are good for 2 years. UM background checks are good for 3.
-                <ul>
-                {% regroup checks|dictsort:"check_type" by get_check_type_display as grouped_checks %}
-                {% for check_type in grouped_checks %}
-                    {% if check_type.list %}
-                    {% with sorted_checks=check_type.list|dictsortreversed:"date_added"  %}
-                    <li><i>{{check_type.grouper}}:</i> {{sorted_checks.0.date_added}}</li>
-                    {% endwith %}
+                    {% if is_user %}<h4>Your info (only visible to you and to admins):</h4>{% endif %}
+                    <p><b>UMID:</b> {{profile.UMID}}</p>
+                    <p><b>Expected Graduation Date:</b> {{profile.expect_grad_date|date:"N j, Y"}}</p>
+                    {% if profile.edu_bckgrd_form %}
+                        <p><b>Educational Background Form:</b> <a href="{{profile.edu_bckgrd_form.url}}">Link</a>
                     {% endif %}
-                {% endfor %}
-                </ul>
-                </p>
+                    <p><b>Alternate email address:</b> <a href="mailto:{{profile.alt_email}}">{{profile.alt_email}}</a></p>
+                    <p><b>Phone number:</b>: {{profile.phone}} </p>
+                    <p><b>Receive Corporate/Job Emails?</b>: {{profile.jobs_email|yesno:"Yes,No"}} </p>
+                    {% if profile.resume %}
+                        <p><b>Resume</b>: <a href="{{profile.resume.url}}">Link</a> </p>
+                    {% endif %}
+                    <p><b>Gender</b>: {{profile.get_gender_display}}</p>
+                    <p><b>Shirt Size</b>: {{profile.shirt_size.name}} </p>
+                    {% if profile.standing.name == "Alumni" %}
+                        <p><b>Desired email frequency </b>:{{profile.get_alum_mail_freq_display}} </p>
+                    {% endif %}
                 {% endif %}
-                <p><b>Alternate email address:</b> <a href="mailto:{{profile.alt_email}}">{{profile.alt_email}}</a></p>
-                <p><b>Phone number:</b>: {{profile.phone}} </p>
-                <p><b>Receive Corporate/Job Emails?</b>: {{profile.jobs_email|yesno:"Yes,No"}} </p>
-                {% if profile.resume %}
-                <p><b>Resume</b>: <a href="{{profile.resume.url}}">Link</a> </p>
-                {% endif %}
-                <p><b>Gender</b>: {{profile.get_gender_display}}</p>
-                <p><b>Shirt Size</b>: {{profile.shirt_size.name}} </p>
-                {% if profile.standing.name == "Alumni" %}
-                <p><b>Desired email frequency </b>:{{profile.get_alum_mail_freq_display}} </p>
-                {% endif %}
+
+                {% if background_check_view and checks %}
+                    <p><b>Background Checks on file:</b><br/>
+                    This lists the date the check was filed. AAPS background checks and BSA training are good for 2 years. UM background checks are good for 3.
+                    <ul>
+                    {% regroup checks|dictsort:"check_type" by get_check_type_display as grouped_checks %}
+                    {% for check_type in grouped_checks %}
+                        {% if check_type.list %}
+                        {% with sorted_checks=check_type.list|dictsortreversed:"date_added"  %}
+                        <li><i>{{check_type.grouper}}:</i> {{sorted_checks.0.date_added}}</li>
+                        {% endwith %}
+                        {% endif %}
+                    {% endfor %}
+                    </ul>
+                    </p>
                 {% endif %}
                 {% endif %}
             </div>

--- a/member_resources/views.py
+++ b/member_resources/views.py
@@ -512,6 +512,9 @@ def profile(request, uniqname):
                             'term': term})
                             
     background_checks = BackgroundCheck.objects.filter(member=profile)
+    show_full_view = is_user or Permissions.can_view_others_data(request.user,
+                                                                 uniqname)
+    show_bg_check_view = show_full_view or Permissions.can_manage_background_checks(request.user)
 
     context_dict = {
         'profile': profile,
@@ -523,13 +526,13 @@ def profile(request, uniqname):
         'awards': profile.award_set.all(),
         'distinction_terms': distinction_terms,
         'is_user': is_user,
-        'full_view': is_user or Permissions.can_view_others_data(request.user,
-                                                                 uniqname),
+        'full_view': show_full_view,
+        'background_check_view': show_bg_check_view,
         'edit': False,
         'has_distinctions': has_distinctions,
         'subnav': 'member_profiles',
         'praise': praise,
-        'checks':background_checks,
+        'checks': background_checks,
     }
     context_dict.update(get_common_context(request))
     context_dict.update(get_permissions(request.user))


### PR DESCRIPTION
Update the `userprofile` view so that K-12 outreach officers can see members’ background check status.

**This PR has not been tested locally.**